### PR TITLE
Upgrade to nxdk version that includes the SEH crash fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Build binary
-      run: docker run -v `pwd`:/usr/src/app -t ghcr.io/xboxdev/nxdk:latest make
+      run: docker run -v `pwd`:/usr/src/app -t ghcr.io/xboxdev/nxdk:git-22565f68 make
     - name: Rename binary
       run: sudo chown -R `id -u`:`id -g` bin && mv bin/default.xbe bin/xblunblock.xbe
     - name: Upload build artifact
@@ -25,7 +25,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Build binary
-      run: docker run -v `pwd`:/usr/src/app -t ghcr.io/xboxdev/nxdk:latest make CXXFLAGS=-DQUICK_MODE
+      run: docker run -v `pwd`:/usr/src/app -t ghcr.io/xboxdev/nxdk:git-22565f68 make CXXFLAGS=-DQUICK_MODE
     - name: Rename binary
       run: sudo chown -R `id -u`:`id -g` bin && mv bin/default.xbe bin/xblunblock_q.xbe
     - name: Upload build artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,13 +8,13 @@ jobs:
     timeout-minutes: 10
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Build binary
       run: docker run -v `pwd`:/usr/src/app -t ghcr.io/xboxdev/nxdk:git-22565f68 make
     - name: Rename binary
       run: sudo chown -R `id -u`:`id -g` bin && mv bin/default.xbe bin/xblunblock.xbe
     - name: Upload build artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: xblunblock.xbe
         path: bin/xblunblock.xbe
@@ -23,13 +23,13 @@ jobs:
     timeout-minutes: 10
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Build binary
       run: docker run -v `pwd`:/usr/src/app -t ghcr.io/xboxdev/nxdk:git-22565f68 make CXXFLAGS=-DQUICK_MODE
     - name: Rename binary
       run: sudo chown -R `id -u`:`id -g` bin && mv bin/default.xbe bin/xblunblock_q.xbe
     - name: Upload build artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: xblunblock_q.xbe
         path: bin/xblunblock_q.xbe
@@ -40,32 +40,15 @@ jobs:
     steps:
     - name: Define Build Tag
       id: build_tag
-      run: echo "::set-output name=BUILD_TAG::v$(date -u +'%Y%m%d%H%M')"
+      run: echo "BUILD_TAG=v$(date -u +'%Y%m%d%H%M')" >> $GITHUB_OUTPUT
     - name: Download artifacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
     - name: Create Release
       id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: softprops/action-gh-release@v1
       with:
+        token: ${{ secrets.GITHUB_TOKEN }}
         tag_name: ${{ steps.build_tag.outputs.BUILD_TAG }}
-        release_name: ${{ steps.build_tag.outputs.BUILD_TAG }}
-    - name: Upload Release Assets
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: xblunblock.xbe/xblunblock.xbe
-        asset_name: xblunblock.xbe
-        asset_content_type: binary/octet-stream
-    - name: Upload Release Assets
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: xblunblock_q.xbe/xblunblock_q.xbe
-        asset_name: xblunblock_q.xbe
-        asset_content_type: binary/octet-stream
+        files: |
+          xblunblock.xbe/xblunblock.xbe
+          xblunblock_q.xbe/xblunblock_q.xbe


### PR DESCRIPTION
This pins the version of the nxdk Docker image we use to one that includes https://github.com/XboxDev/nxdk/pull/619 and also fixes all the deprecated GH Actions stuff.
The crashes and hangs should be fixed by this (a quick test on my Xbox worked just fine).